### PR TITLE
feat: 57/logout : 로그아웃, 회원탈퇴(State변경)

### DIFF
--- a/src/main/java/shop/wannab/userservice/user/controller/UserController.java
+++ b/src/main/java/shop/wannab/userservice/user/controller/UserController.java
@@ -51,4 +51,10 @@ public class UserController {
         userService.deleteUser(userId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/logout")
+    public ResponseEntity<User> logout(@RequestHeader(Util.HEADER_ID_NAME) Long userId) {
+        userService.logout(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/shop/wannab/userservice/user/service/UserService.java
+++ b/src/main/java/shop/wannab/userservice/user/service/UserService.java
@@ -23,4 +23,6 @@ public interface UserService {
     boolean existsUser(long userId);
 
     String reissueToken(String refreshToken);
+
+    void logout(long userId);
 }

--- a/src/main/java/shop/wannab/userservice/user/service/UserServiceImpl.java
+++ b/src/main/java/shop/wannab/userservice/user/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import shop.wannab.userservice.point.domain.dto.PointUpdateDTO;
 import shop.wannab.userservice.user.client.CartClient;
 import shop.wannab.userservice.user.domain.dto.request.UserCreateRequest;
 import shop.wannab.userservice.user.domain.dto.request.UserUpdateRequest;
+import shop.wannab.userservice.user.domain.entity.State;
 import shop.wannab.userservice.user.domain.entity.User;
 import shop.wannab.userservice.user.exception.RefreshTokenNotMatchException;
 import shop.wannab.userservice.user.exception.UserAlreadyExistsException;
@@ -74,7 +75,8 @@ public class UserServiceImpl implements UserService {
         if (!userRepository.existsById(userId)) {
             throw new UserNotFoundException("해당하는 유저 없음");
         }
-        userRepository.deleteById(userId);
+        User user = userRepository.findById(userId).get();
+        user.setState(State.DELETED);
     }
 
     @Override
@@ -111,6 +113,11 @@ public class UserServiceImpl implements UserService {
 
         String newAccessToken = jwtUtil.createAccessToken(userId, role);
         return newAccessToken;
+    }
+
+    @Override
+    public void logout(long userId) {
+        redisTemplate.opsForHash().delete(REFRESH_KEY, userId);
     }
 
 }


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 로그아웃, 회원탈퇴 수정

## 🔎 작업 상세 내용

- [ ] logout - Redis의 userId의 키값으로 가진 refreshToken삭제
- [ ] 회원탈퇴 서비스 로직 delete -> State.DELETED로 변경
      
## ⏰ Pull Request 마감시간
> 2025.07.02 17:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #이슈번호
