### PR TITLE
fix: 페이코 회원가입 에러 해결

### DIFF
--- a/src/main/java/shop/wannab/userservice/auth/service/AuthService.java
+++ b/src/main/java/shop/wannab/userservice/auth/service/AuthService.java
@@ -66,14 +66,15 @@ public class AuthService {
 
     public User buildUserByPaycoLoginRequest(PaycoLoginRequest paycoLoginRequest, UserGrade userGrade) {
         log.info("Service: buildUserByPaycoLoginRequest");
-        String token = (String) redisTemplate.opsForHash().get(REFRESH_KEY, "1");
-        log.info("token: {}", token);
-        return User.social().providerId(paycoLoginRequest.providerId())
-                .email(paycoLoginRequest.email())
-                .phone(paycoLoginRequest.phone())
-                .birth(paycoLoginRequest.birthday())
-                .userGrade(userGrade)
-                .build();
+        return new User(
+                paycoLoginRequest.providerId(),
+                paycoLoginRequest.providerName(),
+                paycoLoginRequest.name(),
+                paycoLoginRequest.email(),
+                paycoLoginRequest.birthday(),
+                userGrade,
+                paycoLoginRequest.phone()
+                );
     }
 
     public void unlockRequest(String userId) {

--- a/src/main/java/shop/wannab/userservice/user/domain/entity/User.java
+++ b/src/main/java/shop/wannab/userservice/user/domain/entity/User.java
@@ -98,6 +98,55 @@ public class User {
     @JoinColumn(name = "grade_id")
     private UserGrade userGrade;
 
+    // 공용 기본값
+    private void initCommonFields(UserGrade userGrade,
+                                  String name,
+                                  String mail,
+                                  String phone,
+                                  LocalDate birth) {
+        this.nickname = "unknown";
+        this.creationAt = LocalDate.now();
+        this.lastLoginAt = null;
+        this.points = 0;
+        this.role = Role.USER;
+        this.state = State.ACTIVATE;
+        this.userGrade = userGrade;
+
+        this.name = name;
+        this.email = mail;
+        this.phone = phone;
+        this.birth = birth;
+    }
+
+    // 일반 회원가입
+    public User(UserGrade userGrade,
+                String password,
+                String userLoginId,
+                String name,
+                String email,
+                String phone,
+                LocalDate birth) {
+        this.userLoginId = userLoginId;
+        this.password = password;
+        this.providerId = null;
+        this.providerName = null;
+        initCommonFields(userGrade, name, email, phone, birth);
+    }
+
+    // 소셜 회원가입
+    public User(String providerId,
+                String providerName,
+                String name,
+                String email,
+                LocalDate birth,
+                UserGrade userGrade,
+                String phone) {
+        this.userLoginId = null;
+        this.password = null;
+        this.providerId = providerId;
+        this.providerName = providerName;
+        initCommonFields(userGrade, name, email, phone, birth);
+    }
 
     // 회원가입
     private User(UserCreateDTO userCreateDTO) {

--- a/src/test/java/shop/wannab/userservice/service/AuthServiceTest.java
+++ b/src/test/java/shop/wannab/userservice/service/AuthServiceTest.java
@@ -277,18 +277,25 @@ class AuthServiceTest {
         // given
         PaycoLoginRequest request = createMockRequest();
 
-        User newUser = User.social()
-                .providerId(request.providerId())
-                .email(request.email())
-                .birth(request.birthday())
-                .phone(request.phone())
-                .build();
+        UserGrade userGrade = new UserGrade();
+
+        User newUser = new User(
+                request.providerId(),
+                request.providerName(),
+                request.name(),
+                request.email(),
+                request.birthday(),
+                userGrade,
+                request.phone()
+        );
+
+
         ReflectionTestUtils.setField(newUser, "userId", 2L);
 
         when(userRepository.existsByProviderId(request.providerId())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenReturn(newUser);
-        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
-        when(hashOperations.get("refresh_token:", "1")).thenReturn("mock-token");
+//        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+//        when(hashOperations.get("refresh_token:", "1")).thenReturn("mock-token");
 
         // when
         Response<PaycoLoginResponse> response = authService.paycoLogin(request);


### PR DESCRIPTION

- <133/페이코 회원가입 에러 해결> 

## 🥳 어떤 기능을 구현했나요?

> 페이코 회원가입 시 필드값이 null로 들어가는 문제 해결

## 🔎 작업 상세 내용

- [x] 페이코 회원가입 시 providerId, providerName이 null로 들어가는 에러 수정
      
## ⏰ Pull Request 마감시간
> 

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #133
